### PR TITLE
Issue 25: EDA on NYC data 

### DIFF
--- a/EDA_forecast_data.Rmd
+++ b/EDA_forecast_data.Rmd
@@ -1,0 +1,219 @@
+---
+title: "EDA_forecast_data"
+output: html_document
+date: "2025-03-11"
+---
+
+The purpose of this Rmarkdown is to get a general sense of the patterns in the
+city-level hospital admissions data for NYC in the
+[flu-metrocast](https://github.com/reichlab/flu-metrocast) Hub.
+
+
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+library(ggplot2)
+library(readr)
+library(feasts)
+library(dplyr)
+library(stats)
+library(lubridate)
+library(tidyr)
+library(tsibble)
+```
+
+## Load in the data
+Plot the raw data. Note, the Hub also contains data on the perent of ED visits
+due to flu in 5 metro areas in Texas. We'll focus on the NYC data for now,
+but most of the transformations and analyses we do here can be duplicated
+on that data.
+```{r}
+raw_data <- read_csv("https://raw.githubusercontent.com/reichlab/flu-metrocast/refs/heads/main/target-data/time-series.csv") # nolint
+NYC_data <- raw_data |>
+  filter(
+    target == "ILI ED visits",
+    as_of == max(as_of),
+    location != "NYC"
+  )
+ggplot(NYC_data) +
+  geom_line(aes(x = target_end_date, y = observation)) +
+  facet_wrap(~location, scales = "free_y", nrow = 7) +
+  xlab("") +
+  ylab("ED visits due to ILI") +
+  ggtitle("NYC data") +
+  theme_bw()
+
+# Create a tsibble object to use with the feasts package
+NYC_data_tsibble <- NYC_data |>
+  mutate(year_week = yearweek(target_end_date)) |>
+  select(-target_end_date, -target, -as_of) |>
+  as_tsibble(key = c(location), index = year_week)
+```
+
+## Assign an epidemic season to the data, and make plots by season
+As a first pass, we could use year to look for seasonality. However, it is
+often easier to think in terms of the epidemic seasons, so we will add this as
+a variable and plot the data by season.
+```{r}
+NYC_clean <- NYC_data |>
+  mutate(
+    year = year(target_end_date),
+    week = week(target_end_date)
+  ) |>
+  # Name the season by the final year e.g. 2023-2024 is the 2024 season
+  mutate(
+    season = ifelse(week < 31, year, year + 1),
+    season_week = ifelse(week < 31, week + (52 - 30), week - 30)
+  ) |>
+  # For simplicity, remove the last week since it is incomplete (only includes
+  # 2 days of data)
+  filter(target_end_date <= as_of)
+
+ggplot(NYC_clean) +
+  geom_line(aes(
+    x = season_week, y = observation,
+    color = as.factor(season)
+  )) +
+  facet_wrap(~location, scales = "free_y", nrow = 7) +
+  theme_bw() +
+  xlab("Week of the season") +
+  ylab("ED visits due to ILI") +
+  labs(color = "Season ending")
+
+ggplot(NYC_clean |> filter(location == "Manhattan")) +
+  geom_line(aes(x = season, y = observation)) +
+  facet_wrap(~season_week) +
+  xlab("Season ending") +
+  ylab("ED visits due to ILI") +
+  ggtitle("Seasonal subseries plot for Manhattan")
+```
+From the seasonal plots, we can see that the peak doesn't always fall on the
+same week of the year, which peak time varying from below week 20 to week 35.
+We can visually see the atypical peak at week 35 observed in 2020 due to the
+COVID pandemic.
+
+## Plot relationships between the time series in each location
+To see the relationships between the time series across locations, we can plot
+them against one another and arrange them in a scatterplot matrix.
+```{r}
+NYC_clean |>
+  ungroup() |>
+  select(target_end_date, observation, location) |>
+  pivot_wider(values_from = observation, names_from = location) |>
+  GGally::ggpairs(columns = 2:7)
+```
+
+This scatterplot reveals strong correlations between all pairs of Manhattan,
+Brooklyn, Queens, and the Bronx, and slightly lower (but still high) correlation
+between Staten Island and the other boroughs. This makes sense, since Staten
+Island tends to be less urban/connected than the other boroughs.
+
+## Lag plots
+
+Next we will make some scatter plots of the correlation between different
+lags in the data. We will start by doing this just for  a single location
+for simplicity.
+
+```{r}
+NYC_clean |>
+  filter(location == "Manhattan") |>
+  ungroup() |>
+  mutate(
+    lag_1 = lag(observation, n = 1),
+    lag_12 = lag(observation, n = 12),
+    lag_24 = lag(observation, n = 24),
+    lag_36 = lag(observation, n = 36),
+    lag_48 = lag(observation, n = 48),
+    lag_52 = lag(observation, n = 52)
+  ) |>
+  pivot_longer(
+    cols = starts_with("lag_"),
+    names_to = "lag",
+    names_prefix = "lag_",
+    values_to = "count"
+  ) |>
+  ggplot() +
+  geom_point(aes(x = count, y = observation)) +
+  facet_wrap(~lag) +
+  xlab("Lagged count") +
+  ylab("count")
+
+# Try using the built in function for a tsibble.
+NYC_data_tsibble |>
+  filter(location == "Manhattan") |>
+  gg_lag(observation, geom = "point", lags = c(1, 12, 24, 36, 48, 52))
+```
+
+Here, we have just plotted the lagged values for a few different lags. We
+can see that the most correlated are the ones 1 week apart. There is some
+correlation between the ones 52 weeks apart, and there appears to be
+negative correlation between the data 24 and 36 weeks apart.
+
+## Autocorrelation function
+Next we will plot an autocorrelation function, which will compute the
+autocorrelation coefficient of the data at each lag
+```{r}
+NYC_data_tsibble |>
+  filter(location == "Manhattan") |>
+  ACF(observation, lag_max = 416) |>
+  autoplot() + labs(title = "Autocorrelation coefficients for Manhattan")
+```
+
+We can see from this plot that multiples of 52 seem to exhibit some degree of
+correlation, and multiples of 52 shifted by 26 produce negative correlations
+(because troughs tend to be a half year behind the peak).
+
+## Data adjustments
+One thing we might really want to do is to adjust this data by population
+size, as this will disentangle changes in ED visits due to ILI driven
+by changes in the population size versus actually infection prevalence.
+
+** To do: find dataset of population sizes over time in NYC **
+
+Another common transformation is to log scale the data, which might make sense
+in our case since we expect epidemic dynamics to follow exponential dynamics.
+
+## Decomposition
+We can attempt to decompose the time series to separate the seasonality trend,
+the trend-cycle, and the remainder i.e.
+$$ y_t = S_t + T_t + R_t $$
+
+We'll start by using a classical decomposition on the data from Manhattan.
+```{r}
+NYC_data_tsibble |>
+  filter(location == "Manhattan") |>
+  model(classical_decomposition(observation, type = "additive")) |>
+  components() |>
+  autoplot() +
+  labs(title = "Classical additive decomposition of ILI ED visits in Manhattan")
+```
+Looking at this, we can see that the "random" or remainder has quite a bit of
+pattern in it. This suggests that we might want to try different
+decomposition methods so that we can capture those in the "trend" component
+instead.
+
+Let's try an STL decomposition
+```{r}
+NYC_data_tsibble |>
+  filter(location == "Manhattan") |>
+  model(STL(
+    observation ~ trend(window = 15) +
+      season(window = 5),
+    robust = TRUE
+  )) |>
+  components() |>
+  autoplot() +
+  labs(title = "STL decomposition of ILI ED visits in Manhattan")
+```
+Here I am setting the trend-cycle window to allow the trend to be learned across
+15 week moving averages (I think). Setting this to be higher will smooth out
+the trend, and put more of the change in the remainder.
+Setting this to be lower will allow more deviation in the trend and less in the
+remainder.
+
+I have set the season window to 5, which results in seasonal trends that are
+learned over moving windows of 5 seasons. This allows for time varying
+seasonality, as we can see in the plot.
+
+We can see the effects of COVID both in the trend (spike in 2020) and also in
+the remainder (spike in 2020). There's also a post-pandemic

--- a/renv.lock
+++ b/renv.lock
@@ -39,6 +39,31 @@
       ],
       "Hash": "00077243042334c50b74cdfafe172870"
     },
+    "GGally": {
+      "Package": "GGally",
+      "Version": "2.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "RColorBrewer",
+        "dplyr",
+        "ggplot2",
+        "ggstats",
+        "grDevices",
+        "grid",
+        "gtable",
+        "lifecycle",
+        "magrittr",
+        "plyr",
+        "progress",
+        "rlang",
+        "scales",
+        "tidyr",
+        "utils"
+      ],
+      "Hash": "b11ac45c916608b7d1374ff87da053d5"
+    },
     "MASS": {
       "Package": "MASS",
       "Version": "7.3-61",
@@ -194,6 +219,18 @@
         "utils"
       ],
       "Hash": "2288423bb0f20a457800d7fc47f6aa54"
+    },
+    "anytime": {
+      "Package": "anytime",
+      "Version": "0.3.11",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "BH",
+        "R",
+        "Rcpp"
+      ],
+      "Hash": "a1db66ce27bcfb58cb67ad4e04d48b79"
     },
     "argparser": {
       "Package": "argparser",
@@ -498,7 +535,7 @@
       "Source": "Repository",
       "Repository": "https://epiforecasts.r-universe.dev",
       "RemoteUrl": "https://github.com/stan-dev/cmdstanr",
-      "RemoteSha": "4e056be9ba0a56192980e8df46a2f6c79982256f",
+      "RemoteSha": "3b6cf27cea54a5955e4cb550cfcbb29bd22f4201",
       "Requirements": [
         "R",
         "R6",
@@ -692,6 +729,17 @@
       ],
       "Hash": "fedd9d00c2944ff00a0e2696ccf048ec"
     },
+    "ellipsis": {
+      "Package": "ellipsis",
+      "Version": "0.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "rlang"
+      ],
+      "Hash": "bb0eec2fe32e88d9e2836c2f73ea2077"
+    },
     "evaluate": {
       "Package": "evaluate",
       "Version": "1.0.1",
@@ -701,6 +749,33 @@
         "R"
       ],
       "Hash": "3fd29944b231036ad67c3edb32e02201"
+    },
+    "fabletools": {
+      "Package": "fabletools",
+      "Version": "0.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R6",
+        "distributional",
+        "dplyr",
+        "generics",
+        "ggdist",
+        "ggplot2",
+        "lifecycle",
+        "progressr",
+        "rlang",
+        "scales",
+        "stats",
+        "tibble",
+        "tidyr",
+        "tidyselect",
+        "tsibble",
+        "utils",
+        "vctrs"
+      ],
+      "Hash": "0242939c5bf3a090df0b8877c7a6c97a"
     },
     "fansi": {
       "Package": "fansi",
@@ -728,6 +803,31 @@
       "Repository": "CRAN",
       "Hash": "aa5e1cd11c2d15497494c5292d7ffcc8"
     },
+    "feasts": {
+      "Package": "feasts",
+      "Version": "0.4.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "dplyr",
+        "fabletools",
+        "ggplot2",
+        "grid",
+        "gtable",
+        "lifecycle",
+        "lubridate",
+        "rlang",
+        "scales",
+        "slider",
+        "tibble",
+        "tidyr",
+        "tsibble",
+        "utils",
+        "vctrs"
+      ],
+      "Hash": "276b81269ccbe43e7ad23fe8d4b4cadd"
+    },
     "fontawesome": {
       "Package": "fontawesome",
       "Version": "0.5.3",
@@ -739,6 +839,22 @@
         "rlang"
       ],
       "Hash": "bd1297f9b5b1fc1372d19e2c4cd82215"
+    },
+    "forcats": {
+      "Package": "forcats",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "rlang",
+        "tibble"
+      ],
+      "Hash": "1a0a9a3d5083d0d573c4214576f1e690"
     },
     "forecasttools": {
       "Package": "forecasttools",
@@ -920,6 +1036,29 @@
         "withr"
       ],
       "Hash": "66488692cb8621bc78df1b9b819497a6"
+    },
+    "ggstats": {
+      "Package": "ggstats",
+      "Version": "0.9.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "dplyr",
+        "forcats",
+        "ggplot2",
+        "lifecycle",
+        "patchwork",
+        "purrr",
+        "rlang",
+        "scales",
+        "stats",
+        "stringr",
+        "tidyr",
+        "utils"
+      ],
+      "Hash": "7970feac45e807dabb5f53add546afcc"
     },
     "gh": {
       "Package": "gh",
@@ -1756,6 +1895,18 @@
       ],
       "Hash": "f4625e061cb2865f111b47ff163a5ca6"
     },
+    "progressr": {
+      "Package": "progressr",
+      "Version": "0.15.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "digest",
+        "utils"
+      ],
+      "Hash": "f8e9876b6ffff900e83f171081cacd6f"
+    },
     "promises": {
       "Package": "promises",
       "Version": "1.3.2",
@@ -2041,6 +2192,20 @@
       ],
       "Hash": "63e4ea2379e79cf18813dd0d8146d27c"
     },
+    "slider": {
+      "Package": "slider",
+      "Version": "0.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "rlang",
+        "vctrs",
+        "warp"
+      ],
+      "Hash": "5dbae6fb8e910b174bc3428164f4e8f8"
+    },
     "smooth": {
       "Package": "smooth",
       "Version": "4.1.1",
@@ -2235,6 +2400,27 @@
       ],
       "Hash": "3ec7e3ddcacc2d34a9046941222bf94d"
     },
+    "tsibble": {
+      "Package": "tsibble",
+      "Version": "1.1.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "anytime",
+        "dplyr",
+        "ellipsis",
+        "generics",
+        "lifecycle",
+        "lubridate",
+        "methods",
+        "rlang",
+        "tibble",
+        "tidyselect",
+        "vctrs"
+      ],
+      "Hash": "10a8318a2264880cf5e83b32241306d2"
+    },
     "tzdb": {
       "Package": "tzdb",
       "Version": "0.4.0",
@@ -2305,6 +2491,16 @@
         "withr"
       ],
       "Hash": "390f9315bc0025be03012054103d227c"
+    },
+    "warp": {
+      "Package": "warp",
+      "Version": "0.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "fea474d578b1cbcb696ae6ac8bdcc439"
     },
     "withr": {
       "Package": "withr",


### PR DESCRIPTION
This PR addresses #25. 

It creates an Rmd that loads in the latest NYC ILI ED visits data from the flu-metrocast Hub. It does some basic EDA to investigate whether we see seasonal trends in the data, to investigate the correlations between the locations, plot the autocorrelation coefficients across lags, and lastly attempts to decompose the time series into trend, season, and remainder components. 

This is based on the examples shown in the first 4 chapters of [FPP](https://otexts.com/fpp3/intro.html). It is meant to illustrate how to apply some of these plotting and summary metrics to a real-world dataset, and also be used to inform our own modeling for the city-forecasting project. 